### PR TITLE
詳細ページのAPIキーをENVで利用

### DIFF
--- a/app/views/favorites/show.html.erb
+++ b/app/views/favorites/show.html.erb
@@ -62,4 +62,4 @@
   }
 </script>
 
-<script async defer src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.credentials.dig(:google_maps, :api_key) %>&libraries=places&callback=initMap"></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY'] %>&libraries=places&callback=initMap" async defer></script>


### PR DESCRIPTION
- 詳細ページのAPIキーをcredentialsではなくENVで利用