### PR TITLE
dockerfileにgem railsを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile
+RUN gem install rails
 
 # Install node modules
 COPY package.json yarn.lock ./


### PR DESCRIPTION
- heroku run rails cで以下のエラーが発生するため追加
/rails/bin/docker-entrypoint: line 8: exec: rails: not found